### PR TITLE
handle saving messages with no parts

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -354,13 +354,13 @@ class Component(ComponentBase):
                 raise UserException("Invalid Sender")
             else:
                 # Load messages parts data
-                for part in message['part_id']:
-                    self._messages_parts_writer.writerow({
-                        'part_id': part,
-                        'message_id': message['message_id']
-                    })
+                if message.get('part_id'):
+                    for part in message['part_id']:
+                        self._messages_parts_writer.writerow({
+                            'part_id': part,
+                            'message_id': message['message_id']
+                        })
 
-                # Load messages data
                 message.pop('part_id', None)
                 self._messages_writer.writerow(message)
 


### PR DESCRIPTION
This is a fix for an issue raised in KCFS-220.
Adds handling of messages with no "part_id". 
This behaviour is described in API docs: https://help.bulkgate.com/docs/en/http-advanced-promotional-v2.html

I have no dev account for Bulkgate so I have no way to test this, but I suspect that instead of responding with na empty array, the api does not contain "part_id" key when message does not get split into parts.